### PR TITLE
add device ident structure

### DIFF
--- a/src/data_type.rs
+++ b/src/data_type.rs
@@ -38,7 +38,7 @@ impl DataType {
             let mut n: $ty = 0;
 
             #[allow(arithmetic_overflow)]
-            for (i, &b) in bytes.into_iter().rev().enumerate() {
+            for (_i, &b) in bytes.into_iter().rev().enumerate() {
               n = (n << 8) | (b as $ty);
             }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,11 @@
+use crate::types::DeviceIdent;
 use std::io;
 use std::fmt;
 use std::error::Error as StdError;
 
 #[derive(Debug)]
 pub enum Error {
-  UnsupportedDevice(u16),
+  UnsupportedDevice(DeviceIdent),
   UnsupportedCommand(String),
   UnsupportedMode(String),
   InvalidArgument(String),
@@ -21,7 +22,7 @@ impl From<io::Error> for Error {
 impl fmt::Display for Error {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      Error::UnsupportedDevice(device_id) => write!(f, "Device ID 0x{:04X} not supported.", device_id),
+      Error::UnsupportedDevice(device_ident) => write!(f, "Device ID 0x{:04X} HX {} SW {} not supported.", device_ident.id, device_ident.hardware_index, device_ident.software_index),
       Error::UnsupportedCommand(command) => write!(f, "command {} is not supported", command),
       Error::UnsupportedMode(description) => description.fmt(f),
       Error::InvalidArgument(description) => description.fmt(f),

--- a/src/types/device_ident.rs
+++ b/src/types/device_ident.rs
@@ -1,0 +1,57 @@
+use std::fmt;
+
+#[derive(Clone)]
+pub struct DeviceIdent {
+    pub id: u16,
+    pub hardware_index: u8,
+    pub software_index: u8,
+    pub protocol_version_lda: u8,
+    pub protocol_version_rda: u8,
+    pub developer_version: u16,
+}
+
+impl fmt::Debug for DeviceIdent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Device ID 0x{:04X}, HX {}, SW {}, LDA {}, RDA {}, DEV 0x{:04X}",
+            self.id,
+            self.hardware_index,
+            self.software_index,
+            self.protocol_version_lda,
+            self.protocol_version_rda,
+            self.developer_version
+        )
+    }
+}
+
+impl DeviceIdent {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        Self {
+            id: u16::from_be_bytes(bytes[0..2].try_into().unwrap()),
+            hardware_index: u8::from_be_bytes(bytes[2..3].try_into().unwrap()),
+            software_index: u8::from_be_bytes(bytes[3..4].try_into().unwrap()),
+            protocol_version_lda: u8::from_be_bytes(bytes[4..5].try_into().unwrap()),
+            protocol_version_rda: u8::from_be_bytes(bytes[5..6].try_into().unwrap()),
+            developer_version: u16::from_be_bytes(bytes[6..8].try_into().unwrap()),
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; 8] {
+        let id = self.id.to_be_bytes();
+        let hardware_index = self.hardware_index.to_be_bytes();
+        let software_index = self.software_index.to_be_bytes();
+        let protocol_version_lda = self.protocol_version_lda.to_be_bytes();
+        let protocol_version_rda = self.protocol_version_rda.to_be_bytes();
+        let developer_version = self.developer_version.to_be_bytes();
+
+        [
+            id[0], id[1],
+            hardware_index[0],
+            software_index[0],
+            protocol_version_lda[0],
+            protocol_version_rda[0],
+            developer_version[0], developer_version[1],
+        ]
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,9 @@
 mod cycle_time;
 pub use self::cycle_time::{CycleTime, CycleTimes};
 
+mod device_ident;
+pub use self::device_ident::DeviceIdent;
+
 mod error;
 pub use self::error::Error;
 

--- a/src/vcontrol.rs
+++ b/src/vcontrol.rs
@@ -1,3 +1,4 @@
+use crate::types::DeviceIdent;
 use crate::{Error, Optolink, Device, device::DEVICES, Protocol, Value};
 
 /// Representation of an `Optolink` connection to a specific `Device` using a specific `Protocol`.
@@ -30,16 +31,17 @@ impl VControl {
       (false, protocol)
     };
 
-    let mut buf = [0; 2];
+    let mut buf = [0; 8];
     protocol.get(&mut optolink, 0x00f8, &mut buf)?;
-    let device_id = u16::from_be_bytes(buf);
-    let device_id_full = ((device_id as u64) << 48);
+
+    let device_ident = DeviceIdent::from_bytes(&buf);
+    let device_id_full = ((device_ident.id as u64) << 48);
 
     let device = if let Some(device) = DEVICES.get(&device_id_full) {
       log::debug!("Device detected: {}", device.name());
       *device
     } else {
-      return Err(Error::UnsupportedDevice(device_id))
+      return Err(Error::UnsupportedDevice(device_ident))
     };
 
     let mut vcontrol = VControl { optolink, device, connected, protocol };


### PR DESCRIPTION
Currently I can't connect as my device is not recognized. You must not filter out all the device revisions. IdentificationExtension and IdentificationExtensionTill form two ranges where the upper byte is the supported hardware index and the lower one the supported software index.

A little bit strange: my device is identified as ID 0x20CB, HX 0, SW 8, but the list of valid hardware indexes is only HX 1. Did you encounter something similar too?

Signed-off-by: Jens Mueller <tschenser@gmx.de>