### PR TITLE
Make API async.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ arrayref = "0.3.6"
 tokio = { version = "1.0", features = ["io-util", "macros", "net"] }
 tokio-serial = "5.4.2"
 pin-project = "1.0.10"
+num_enum = "0.5.7"
 
 [[bin]]
 name = "vcontrol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "ReadMe.md"
 [features]
 cli = ["actix-rt", "clap", "serde_json", "env_logger", "impl_webthing", "impl_json_schema"]
 impl_json_schema = ["schemars"]
-impl_webthing = ["impl_json_schema", "serde_json", "webthing", "tokio"]
+impl_webthing = ["impl_json_schema", "serde_json", "webthing", "tokio", "actix-rt"]
 
 [dependencies]
 actix-rt = { version = "2.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "ReadMe.md"
 [features]
 cli = ["actix-rt", "clap", "serde_json", "env_logger", "impl_webthing", "impl_json_schema"]
 impl_json_schema = ["schemars"]
-impl_webthing = ["impl_json_schema", "serde_json", "webthing", "tokio", "actix-rt"]
+impl_webthing = ["impl_json_schema", "serde_json", "webthing", "actix-rt"]
 cat = ["env_logger", "tokio/rt-multi-thread"]
 
 [dependencies]
@@ -32,7 +32,7 @@ env_logger = { version = "0.9.0", optional = true }
 webthing = { version = "0.15.0", optional = true }
 schemars = { version = "0.8.8", optional = true }
 arrayref = "0.3.6"
-tokio = { version = "1.0", features = ["macros"], optional = true }
+tokio = { version = "1.0", features = ["io-util", "macros", "net"] }
 tokio-serial = "5.4.2"
 pin-project = "1.0.10"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
 phf = { version = "0.10", features = ["serde"] }
 phf_shared = "0.10"
-serial = "0.4"
-serial-core = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", optional = true }
 env_logger = { version = "0.9.0", optional = true }
@@ -34,6 +32,8 @@ webthing = { version = "0.15.0", optional = true }
 schemars = { version = "0.8.8", optional = true }
 arrayref = "0.3.6"
 tokio = { version = "1.0", features = ["macros"], optional = true }
+tokio-serial = "5.4.2"
+pin-project = "1.0.10"
 
 [[bin]]
 name = "vcontrol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ readme = "ReadMe.md"
 cli = ["actix-rt", "clap", "serde_json", "env_logger", "impl_webthing", "impl_json_schema"]
 impl_json_schema = ["schemars"]
 impl_webthing = ["impl_json_schema", "serde_json", "webthing", "tokio", "actix-rt"]
+cat = ["env_logger", "tokio/rt-multi-thread"]
 
 [dependencies]
 actix-rt = { version = "2.7", optional = true }
@@ -41,7 +42,7 @@ required-features = ["cli"]
 
 [[example]]
 name = "cat"
-required-features = ["env_logger"]
+required-features = ["cat"]
 
 [[example]]
 name = "scan"

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -4,17 +4,18 @@ use std::error::Error;
 
 use vcontrol::{Optolink, VControl, Value};
 
-fn main() -> Result<(), Box<dyn Error + Send + Sync>>  {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>>  {
   env_logger::init();
 
   let optolink_port = env::args().nth(1).expect("no serial port specified");
   let optolink = if optolink_port.contains(':') {
-    Optolink::connect(optolink_port)
+    Optolink::connect(optolink_port).await
   } else {
-    Optolink::open(optolink_port)
+    Optolink::open(optolink_port).await
   }?;
 
-  let mut vcontrol = VControl::connect(optolink)?;
+  let mut vcontrol = VControl::connect(optolink).await?;
 
   log::info!("Connected to '{}' via {} protocol.", vcontrol.device().name(), vcontrol.protocol());
 
@@ -37,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync>>  {
       continue;
     }
 
-    let res = vcontrol.get(key);
+    let res = vcontrol.get(key).await;
 
     match res {
       Ok(value) => {

--- a/src/command.rs
+++ b/src/command.rs
@@ -161,7 +161,7 @@ impl Command {
     Ok(value)
   }
 
-  pub fn get(&self, o: &mut Optolink, protocol: Protocol) -> Result<Value, Error> {
+  pub async fn get(&self, o: &mut Optolink, protocol: Protocol) -> Result<Value, Error> {
     log::trace!("Command::get(…)");
 
     if !self.mode.is_read() {
@@ -169,7 +169,7 @@ impl Command {
     }
 
     let mut buf = vec![0; self.block_len];
-    protocol.get(o, self.addr, &mut buf)?;
+    protocol.get(o, self.addr, &mut buf).await?;
 
     let bytes = &buf[self.byte_pos..(self.byte_pos + self.byte_len)];
 
@@ -189,7 +189,7 @@ impl Command {
     }
   }
 
-  pub fn set(&self, o: &mut Optolink, protocol: Protocol, mut input: Value) -> Result<(), Error> {
+  pub async fn set(&self, o: &mut Optolink, protocol: Protocol, mut input: Value) -> Result<(), Error> {
     log::trace!("Command::set(…)");
 
     if !self.mode.is_write() {
@@ -277,6 +277,6 @@ impl Command {
       }
     };
 
-    protocol.set(o, self.addr, &bytes).map_err(Into::into)
+    protocol.set(o, self.addr, &bytes).await.map_err(Into::into)
   }
 }

--- a/src/optolink.rs
+++ b/src/optolink.rs
@@ -82,8 +82,6 @@ pub struct Optolink {
 }
 
 impl Optolink {
-  pub(crate) const TIMEOUT: Duration = Duration::from_secs(60);
-
   /// Opens a serial device.
   ///
   /// # Examples

--- a/src/optolink.rs
+++ b/src/optolink.rs
@@ -91,8 +91,8 @@ impl Optolink {
   /// ```no_run
   /// use vcontrol::Optolink;
   ///
-  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-  /// let mut device = Optolink::open("/dev/ttyUSB0")?;
+  /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+  /// let mut device = Optolink::open("/dev/ttyUSB0").await?;
   /// # Ok(())
   /// # }
   /// ```
@@ -126,8 +126,8 @@ impl Optolink {
   /// ```no_run
   /// use vcontrol::Optolink;
   ///
-  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-  /// let mut device = Optolink::connect(("localhost", 1234))?;
+  /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+  /// let mut device = Optolink::connect(("localhost", 1234)).await?;
   /// # Ok(())
   /// # }
   /// ```

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -17,12 +17,12 @@ pub enum Protocol {
 
 impl Protocol {
   /// Try detecting the protocol automatically.
-  pub fn detect(o: &mut Optolink) -> Option<Self> {
-    if Vs2::negotiate(o).is_ok() {
+  pub async fn detect(o: &mut Optolink) -> Option<Self> {
+    if Vs2::negotiate(o).await.is_ok() {
       return Some(Self::Vs2)
     }
 
-    if Vs1::negotiate(o).is_ok() {
+    if Vs1::negotiate(o).await.is_ok() {
       return Some(Self::Vs1)
     }
 
@@ -30,26 +30,26 @@ impl Protocol {
   }
 
   /// Negotiate the protocol.
-  pub fn negotiate(&self, o: &mut Optolink) -> Result<(), io::Error> {
+  pub async fn negotiate(&self, o: &mut Optolink) -> Result<(), io::Error> {
     match self {
-      Self::Vs1 => Vs1::negotiate(o),
-      Self::Vs2 => Vs2::negotiate(o),
+      Self::Vs1 => Vs1::negotiate(o).await,
+      Self::Vs2 => Vs2::negotiate(o).await,
     }
   }
 
   /// Reads the value at the address `addr` into `buf`.
-  pub fn get(&self, o: &mut Optolink, addr: u16, buf: &mut [u8]) -> Result<(), io::Error> {
+  pub async fn get(&self, o: &mut Optolink, addr: u16, buf: &mut [u8]) -> Result<(), io::Error> {
     match self {
-      Self::Vs1 => Vs1::get(o, addr, buf),
-      Self::Vs2 => Vs2::get(o, addr, buf),
+      Self::Vs1 => Vs1::get(o, addr, buf).await,
+      Self::Vs2 => Vs2::get(o, addr, buf).await,
     }
   }
 
   /// Writes the given value `value` to the the address `addr`.
-  pub fn set(&self, o: &mut Optolink, addr: u16, value: &[u8]) -> Result<(), io::Error> {
+  pub async fn set(&self, o: &mut Optolink, addr: u16, value: &[u8]) -> Result<(), io::Error> {
     match self {
-      Self::Vs1 => Vs1::set(o, addr, value),
-      Self::Vs2 => Vs2::set(o, addr, value),
+      Self::Vs1 => Vs1::set(o, addr, value).await,
+      Self::Vs2 => Vs2::set(o, addr, value).await,
     }
   }
 }

--- a/src/protocol/vs1.rs
+++ b/src/protocol/vs1.rs
@@ -29,8 +29,6 @@ impl Vs1 {
 
     let mut buf = [0xff];
 
-    let start = Instant::now();
-
     // Reset the Optolink connection to get a faster `SYNC` (`0x05`).
     Self::negotiate(o).await?;
 
@@ -41,15 +39,7 @@ impl Vs1 {
         o.purge().await?;
         return Ok(())
       }
-
-      let stop = Instant::now();
-
-      if (stop - start) > Optolink::TIMEOUT {
-        break
-      }
     }
-
-    Err(io::Error::new(io::ErrorKind::TimedOut, "sync timed out"))
   }
 
   pub async fn negotiate(o: &mut Optolink) -> Result<(), io::Error> {
@@ -69,8 +59,6 @@ impl Vs1 {
     vec.extend(&[0x01, Function::VirtualRead as u8]);
     vec.extend(addr.to_be_bytes());
     vec.extend(&[buf.len() as u8]);
-
-    let start = Instant::now();
 
     Self::sync(o).await?;
 
@@ -104,13 +92,7 @@ impl Vs1 {
       } else {
         return Ok(())
       }
-
-      if (stop - start) > Optolink::TIMEOUT {
-        break
-      }
     }
-
-    Err(io::Error::new(io::ErrorKind::TimedOut, "get timed out"))
   }
 
   pub async fn set(o: &mut Optolink, addr: u16, value: &[u8]) -> Result<(), io::Error> {
@@ -122,8 +104,6 @@ impl Vs1 {
     vec.extend(&[value.len() as u8]);
     vec.extend(value);
 
-    let start = Instant::now();
-
     Self::sync(o).await?;
 
     loop {
@@ -133,17 +113,9 @@ impl Vs1 {
       let mut buf = [0xff];
       o.read_exact(&mut buf).await?;
 
-      let stop = Instant::now();
-
       if buf == [0x00] {
         return Ok(())
       }
-
-      if (stop - start) > Optolink::TIMEOUT {
-        break
-      }
     }
-
-    Err(io::Error::new(io::ErrorKind::TimedOut, "set timed out"))
   }
 }

--- a/src/protocol/vs1.rs
+++ b/src/protocol/vs1.rs
@@ -22,7 +22,7 @@ enum Function {
 pub enum Vs1 {}
 
 impl Vs1 {
-  fn sync(o: &mut Optolink) -> Result<(), std::io::Error> {
+  async fn sync(o: &mut Optolink) -> Result<(), std::io::Error> {
     log::trace!("Vs1::sync(…)");
 
     let mut buf = [0xff];
@@ -30,7 +30,7 @@ impl Vs1 {
     let start = Instant::now();
 
     // Reset the Optolink connection to get a faster `SYNC` (`0x05`).
-    Self::negotiate(o)?;
+    Self::negotiate(o).await?;
 
     loop {
       log::trace!("Vs1::sync(…) loop");
@@ -50,7 +50,7 @@ impl Vs1 {
     Err(io::Error::new(io::ErrorKind::TimedOut, "sync timed out"))
   }
 
-  pub fn negotiate(o: &mut Optolink) -> Result<(), io::Error> {
+  pub async fn negotiate(o: &mut Optolink) -> Result<(), io::Error> {
     log::trace!("Vs1::negotiate(…)");
 
     o.purge()?;
@@ -60,7 +60,7 @@ impl Vs1 {
     Ok(())
   }
 
-  pub fn get(o: &mut Optolink, addr: u16, buf: &mut [u8]) -> Result<(), io::Error> {
+  pub async fn get(o: &mut Optolink, addr: u16, buf: &mut [u8]) -> Result<(), io::Error> {
     log::trace!("Vs1::get(…)");
 
     let mut vec = Vec::new();
@@ -70,7 +70,7 @@ impl Vs1 {
 
     let start = Instant::now();
 
-    Self::sync(o)?;
+    Self::sync(o).await?;
 
     loop {
       log::trace!("Vs1::get(…) loop");
@@ -111,7 +111,7 @@ impl Vs1 {
     Err(io::Error::new(io::ErrorKind::TimedOut, "get timed out"))
   }
 
-  pub fn set(o: &mut Optolink, addr: u16, value: &[u8]) -> Result<(), io::Error> {
+  pub async fn set(o: &mut Optolink, addr: u16, value: &[u8]) -> Result<(), io::Error> {
     log::trace!("Vs1::set(…)");
 
     let mut vec = Vec::new();
@@ -122,7 +122,7 @@ impl Vs1 {
 
     let start = Instant::now();
 
-    Self::sync(o)?;
+    Self::sync(o).await?;
 
     loop {
       o.write_all(&vec)?;

--- a/src/protocol/vs2.rs
+++ b/src/protocol/vs2.rs
@@ -198,13 +198,11 @@ impl Vs2 {
 
         o.read_exact(*payload).await?;
         checksum = checksum.wrapping_add(wrapping_sum(&**payload));
-      } else {
-        if message_len != 5 {
-          return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("invalid message length, expected 5, got {}", message_len)
-          ))
-        }
+      } else if message_len != 5 {
+        return Err(io::Error::new(
+          io::ErrorKind::InvalidData,
+          format!("invalid message length, expected 5, got {}", message_len)
+        ))
       }
 
       o.read_exact(&mut buf).await?;

--- a/src/protocol/vs2.rs
+++ b/src/protocol/vs2.rs
@@ -73,7 +73,7 @@ enum Function {
 pub enum Vs2 {}
 
 impl Vs2 {
-  fn write_telegram(o: &mut Optolink, message: &[u8]) -> Result<(), std::io::Error> {
+  async fn write_telegram(o: &mut Optolink, message: &[u8]) -> Result<(), std::io::Error> {
     log::trace!("Vs2::write_telegram(…)");
 
     let message_length = message.len() as u8;
@@ -106,7 +106,7 @@ impl Vs2 {
     Err(io::Error::new(io::ErrorKind::TimedOut, "send telegram timed out"))
   }
 
-  fn read_telegram(o: &mut Optolink) -> Result<Vec<u8>, std::io::Error> {
+  async fn read_telegram(o: &mut Optolink) -> Result<Vec<u8>, std::io::Error> {
     log::trace!("Vs2::read_telegram(…)");
 
     let mut buf = [0xff];
@@ -148,7 +148,7 @@ impl Vs2 {
     Err(io::Error::new(io::ErrorKind::TimedOut, "send telegram timed out"))
   }
 
-  pub fn negotiate(o: &mut Optolink) -> Result<(), io::Error> {
+  pub async fn negotiate(o: &mut Optolink) -> Result<(), io::Error> {
     log::trace!("Vs2::negotiate(…)");
 
     o.write_all(&RESET)?;
@@ -185,7 +185,7 @@ impl Vs2 {
     Err(io::Error::new(io::ErrorKind::TimedOut, "negotiate timed out"))
   }
 
-  pub fn get(o: &mut Optolink, addr: u16, buf: &mut [u8]) -> Result<(), io::Error> {
+  pub async fn get(o: &mut Optolink, addr: u16, buf: &mut [u8]) -> Result<(), io::Error> {
     log::trace!("Vs2::get(…)");
 
     let addr = addr.to_be_bytes();
@@ -195,9 +195,9 @@ impl Vs2 {
     read_request.extend(addr);
     read_request.extend(&[buf.len() as u8]);
 
-    Self::write_telegram(o, &read_request)?;
+    Self::write_telegram(o, &read_request).await?;
 
-    let read_response = Self::read_telegram(o)?;
+    let read_response = Self::read_telegram(o).await?;
 
     let expected_len: usize = 5 + buf.len();
     if expected_len != read_response.len() {
@@ -218,7 +218,7 @@ impl Vs2 {
     Ok(())
   }
 
-  pub fn set(o: &mut Optolink, addr: u16, value: &[u8]) -> Result<(), io::Error> {
+  pub async fn set(o: &mut Optolink, addr: u16, value: &[u8]) -> Result<(), io::Error> {
     log::trace!("Vs2::set(…)");
 
     let addr = addr.to_be_bytes();
@@ -229,9 +229,9 @@ impl Vs2 {
     write_request.extend(&[value.len() as u8]);
     write_request.extend(value);
 
-    Self::write_telegram(o, &write_request)?;
+    Self::write_telegram(o, &write_request).await?;
 
-    let write_response = Self::read_telegram(o)?;
+    let write_response = Self::read_telegram(o).await?;
 
     let expected_len: usize = 5;
     if expected_len != write_response.len() {

--- a/src/types/circuit_time.rs
+++ b/src/types/circuit_time.rs
@@ -7,7 +7,7 @@ use schemars::JsonSchema;
 use serde::{Serialize, Serializer, de, Deserialize, Deserializer};
 
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CircuitTimes {
   mon: CircuitTime,
   tue: CircuitTime,
@@ -53,7 +53,7 @@ impl CircuitTimes {
 }
 
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct CircuitTime([Option<TimeSpan>; 4]);
 
 impl CircuitTime {
@@ -111,7 +111,7 @@ impl fmt::Debug for CircuitTime {
 }
 
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 struct TimeSpan {
   from: Time,
   to: Time,

--- a/src/types/date_time.rs
+++ b/src/types/date_time.rs
@@ -16,7 +16,7 @@ fn dec_to_byte(dec: u8) -> u8 {
   dec / 10 * 16 + dec % 10
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Date(pub(crate) NaiveDate);
 
 impl Date {
@@ -101,7 +101,7 @@ impl fmt::Debug for Date {
   }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct DateTime(pub(crate) NaiveDateTime);
 
 impl DateTime {

--- a/src/types/device_id.rs
+++ b/src/types/device_id.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Deserialize};
 
 /// Device identifier.
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct DeviceId {
   pub(crate) group_id: u8,
   pub(crate) id: u8,
@@ -46,7 +46,7 @@ impl DeviceId {
 
 /// Device F0 identifier.
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct DeviceIdF0(pub(crate) u16);
 
 impl DeviceIdF0 {

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -9,7 +9,7 @@ use crate::Device;
 use super::DateTime;
 
 #[cfg_attr(feature = "impl_json_schema", derive(JsonSchema))]
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
 pub struct Error {
   index: u8,
   time: DateTime,

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,7 +6,7 @@ use serde::{Serialize, Deserialize};
 
 use crate::{conversion::Conversion, types::{DeviceId, DeviceIdF0, Date, DateTime, CircuitTimes, Error}};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Value {
   DeviceId(DeviceId),

--- a/src/value.rs
+++ b/src/value.rs
@@ -9,7 +9,9 @@ use crate::{conversion::Conversion, types::{DeviceId, DeviceIdF0, Date, DateTime
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Value {
+  #[serde(skip_deserializing)]
   DeviceId(DeviceId),
+  #[serde(skip_deserializing)]
   DeviceIdF0(DeviceIdF0),
   Int(i64),
   Double(f64),


### PR DESCRIPTION
The previous blocking serial implementation was consistently failing (with timeout) for some commands. The same commands were working fine when debugging via the blocking `TcpStream` implementation over `ser2net`.

Switching to `tokio_serial` (and `tokio::net`) resolves this issue.